### PR TITLE
Refactored config handling

### DIFF
--- a/internal/commands/app.go
+++ b/internal/commands/app.go
@@ -5,22 +5,12 @@ import (
 	"github.com/urfave/cli"
 )
 
-var (
-	// TrelloToken <tbd>
-	TrelloToken string
-	// TrelloAppKey <tbd>
-	TrelloAppKey string
-	// List <tbd>
-	List string
-)
-
 // GetApp <tbd>
-func GetApp(cfg types.Configuration) *cli.App {
-
+func GetApp(cfg types.Configuration, version string) *cli.App {
 	app := cli.NewApp()
-	app.Name = cfg.AppName
-	app.Usage = cfg.AppUsage
-	app.Version = cfg.AppVersion
+	app.Name = "treta"
+	app.Usage = "A simple cli to print cards of a defined trello list"
+	app.Version = version
 
 	cli.VersionFlag = cli.BoolFlag{
 		Name:  "version, v",

--- a/internal/types/structs.go
+++ b/internal/types/structs.go
@@ -2,9 +2,6 @@ package types
 
 // Configuration <tbd>
 type Configuration struct {
-	AppUsage       string
-	AppName        string
-	AppVersion     string
 	TrelloToken    string
 	TrelloAppKey   string
 	TrelloUserName string

--- a/main.go
+++ b/main.go
@@ -20,11 +20,8 @@ var (
 )
 
 func main() {
-	var Cfg = types.Configuration{
-		AppUsage:   "A simple cli to print cards of a defined trello list",
-		AppName:    "treta",
-		AppVersion: AppVersion,
-		Debug:      "false",
+	var cfg = types.Configuration{
+		Debug: "false",
 	}
 
 	user, err := user.Current()
@@ -41,13 +38,13 @@ func main() {
 	if _, err := os.Stat(configFile); err == nil {
 		file, err := os.Open(configFile)
 		decoder := json.NewDecoder(file)
-		err = decoder.Decode(&Cfg)
+		err = decoder.Decode(&cfg)
 		if err != nil {
 			os.Exit(1)
 		}
 	}
 
-	app := commands.GetApp(Cfg)
+	app := commands.GetApp(cfg, AppVersion)
 
 	if err := app.Run(os.Args); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
Use the configuration struct only for user provided config to
a) ease the understanding of the configuration for the user
b) prevent the user from accidently overwritting static values like the
help or version